### PR TITLE
fix(ag-grid): resolves deprecation of showLoadingOverlay()

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -118,7 +118,7 @@ const HomePage = () => {
     updateColumnVisibility(params.api);
 
     if (rowData === null) {
-      params.api.showLoadingOverlay();
+      params.api.setGridOption("loading", true);
     }
   }, [rowData, updateColumnVisibility]);
 
@@ -127,10 +127,12 @@ const HomePage = () => {
     if (!api) return;
 
     if (rowData === null) {
-      api.showLoadingOverlay();
+      api.setGridOption("loading", true);
     } else if (rowData.length === 0) {
       api.showNoRowsOverlay();
+      api.setGridOption("loading", false);
     } else {
+      api.setGridOption("loading", false);
       api.hideOverlay();
     }
   }, [rowData]);


### PR DESCRIPTION
Resolves a deprecation notice for custom AG Grid loading state element.

<img width="1785" height="1116" alt="Screenshot 2026-02-09 at 12 24 43 AM" src="https://github.com/user-attachments/assets/6bb8fedc-6810-4d35-83ce-0d997d692334" />
