### PR TITLE
Integrate @chronogrove/ui (theme switching, backdrop, AG Grid fixes)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  transpilePackages: [
+    "@chronogrove/ui",
+    "@theme-ui/components",
+    "@theme-ui/presets",
+    "@theme-toggles/react",
+    "theme-ui",
+    "three",
+  ],
+};
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -11,11 +11,15 @@
     "convert:csv": "node scripts/convert-csv-to-json.js"
   },
   "dependencies": {
+    "@chronogrove/ui": "^0.82.0",
+    "@emotion/react": "^11.14.0",
+    "@theme-ui/components": "^0.17.4",
     "ag-grid-community": "^35.2.1",
     "ag-grid-react": "^35.2.1",
     "next": "^16.2.3",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "theme-ui": "^0.17.4",
     "webmidi": "^3.1.16"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@chronogrove/ui':
+        specifier: ^0.82.0
+        version: 0.82.0(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@emotion/react':
+        specifier: ^11.14.0
+        version: 11.14.0(react@19.2.5)
+      '@theme-ui/components':
+        specifier: ^0.17.4
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(react@19.2.5)
       ag-grid-community:
         specifier: ^35.2.1
         version: 35.2.1
@@ -23,6 +32,9 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      theme-ui:
+        specifier: ^0.17.4
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
       webmidi:
         specifier: ^3.1.16
         version: 3.1.16
@@ -58,12 +70,113 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@chronogrove/ui@0.82.0':
+    resolution: {integrity: sha512-t9rC1h2uueLBzO/PgsONJI+gm8Xgs6CKis1jIx91apYt0KWPAbudkDAjisSBaYellhTWwEbm6Cs3NH8k8A9W5g==}
+    peerDependencies:
+      next: ^14.0.0 || ^15.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      next:
+        optional: true
+
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emotion/babel-plugin@11.13.5':
+    resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
+
+  '@emotion/cache@11.14.0':
+    resolution: {integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==}
+
+  '@emotion/hash@0.9.2':
+    resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
+
+  '@emotion/is-prop-valid@0.8.8':
+    resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
+
+  '@emotion/memoize@0.7.4':
+    resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+
+  '@emotion/memoize@0.7.5':
+    resolution: {integrity: sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==}
+
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
+
+  '@emotion/react@11.14.0':
+    resolution: {integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@emotion/serialize@1.3.3':
+    resolution: {integrity: sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==}
+
+  '@emotion/sheet@1.4.0':
+    resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
+
+  '@emotion/unitless@0.10.0':
+    resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
+    resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@emotion/utils@1.4.2':
+    resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
+
+  '@emotion/weak-memoize@0.4.0':
+    resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -102,6 +215,21 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fortawesome/fontawesome-common-types@7.2.0':
+    resolution: {integrity: sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/fontawesome-svg-core@7.2.0':
+    resolution: {integrity: sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/react-fontawesome@3.3.0':
+    resolution: {integrity: sha512-EHmHeTf8WgO29sdY3iX/7ekE3gNUdlc2RW6mm/FzELlHFKfTrA9S4MlyquRR+RRCRCn8+jXfLFpLGB2l7wCWyw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@fortawesome/fontawesome-svg-core': ~6 || ~7
+      react: ^18.0.0 || ^19.0.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -335,14 +463,175 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@styled-system/background@5.1.2':
+    resolution: {integrity: sha512-jtwH2C/U6ssuGSvwTN3ri/IyjdHb8W9X/g8Y0JLcrH02G+BW3OS8kZdHphF1/YyRklnrKrBT2ngwGUK6aqqV3A==}
+
+  '@styled-system/border@5.1.5':
+    resolution: {integrity: sha512-JvddhNrnhGigtzWRCVuAHepniyVi6hBlimxWDVAdcTuk7aRn9BYJUwfHslURtwYFsF5FoEs8Zmr1oZq2M1AP0A==}
+
+  '@styled-system/color@5.1.2':
+    resolution: {integrity: sha512-1kCkeKDZkt4GYkuFNKc7vJQMcOmTl3bJY3YBUs7fCNM6mMYJeT1pViQ2LwBSBJytj3AB0o4IdLBoepgSgGl5MA==}
+
+  '@styled-system/core@5.1.2':
+    resolution: {integrity: sha512-XclBDdNIy7OPOsN4HBsawG2eiWfCcuFt6gxKn1x4QfMIgeO6TOlA2pZZ5GWZtIhCUqEPTgIBta6JXsGyCkLBYw==}
+
+  '@styled-system/css@5.1.5':
+    resolution: {integrity: sha512-XkORZdS5kypzcBotAMPBoeckDs9aSZVkvrAlq5K3xP8IMAUek+x2O4NtwoSgkYkWWzVBu6DGdFZLR790QWGG+A==}
+
+  '@styled-system/flexbox@5.1.2':
+    resolution: {integrity: sha512-6hHV52+eUk654Y1J2v77B8iLeBNtc+SA3R4necsu2VVinSD7+XY5PCCEzBFaWs42dtOEDIa2lMrgL0YBC01mDQ==}
+
+  '@styled-system/grid@5.1.2':
+    resolution: {integrity: sha512-K3YiV1KyHHzgdNuNlaw8oW2ktMuGga99o1e/NAfTEi5Zsa7JXxzwEnVSDSBdJC+z6R8WYTCYRQC6bkVFcvdTeg==}
+
+  '@styled-system/layout@5.1.2':
+    resolution: {integrity: sha512-wUhkMBqSeacPFhoE9S6UF3fsMEKFv91gF4AdDWp0Aym1yeMPpqz9l9qS/6vjSsDPF7zOb5cOKC3tcKKOMuDCPw==}
+
+  '@styled-system/position@5.1.2':
+    resolution: {integrity: sha512-60IZfMXEOOZe3l1mCu6sj/2NAyUmES2kR9Kzp7s2D3P4qKsZWxD1Se1+wJvevb+1TP+ZMkGPEYYXRyU8M1aF5A==}
+
+  '@styled-system/shadow@5.1.2':
+    resolution: {integrity: sha512-wqniqYb7XuZM7K7C0d1Euxc4eGtqEe/lvM0WjuAFsQVImiq6KGT7s7is+0bNI8O4Dwg27jyu4Lfqo/oIQXNzAg==}
+
+  '@styled-system/should-forward-prop@5.1.5':
+    resolution: {integrity: sha512-+rPRomgCGYnUIaFabDoOgpSDc4UUJ1KsmlnzcEp0tu5lFrBQKgZclSo18Z1URhaZm7a6agGtS5Xif7tuC2s52Q==}
+
+  '@styled-system/space@5.1.2':
+    resolution: {integrity: sha512-+zzYpR8uvfhcAbaPXhH8QgDAV//flxqxSjHiS9cDFQQUSznXMQmxJegbhcdEF7/eNnJgHeIXv1jmny78kipgBA==}
+
+  '@styled-system/typography@5.1.2':
+    resolution: {integrity: sha512-BxbVUnN8N7hJ4aaPOd7wEsudeT7CxarR+2hns8XCX1zp0DFfbWw4xYa/olA0oQaqx7F1hzDg+eRaGzAJbF+jOg==}
+
+  '@styled-system/variant@5.1.5':
+    resolution: {integrity: sha512-Yn8hXAFoWIro8+Q5J8YJd/mP85Teiut3fsGVR9CAxwgNfIAiqlYxsk5iHU7VHJks/0KjL4ATSjmbtCDC/4l1qw==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@theme-toggles/react@4.1.0':
+    resolution: {integrity: sha512-h3SuJMsej8DfelHt5fjNIlaMfJOK52Vku4pPDVoHaTwjAcoTr4fn8hzeur2oiqWBYFYfKugvv1RdQaBFXaiPKg==}
+    peerDependencies:
+      react: ^16 || ^17 || ^18
+      react-dom: ^16 || ^17 || ^18
+
+  '@theme-ui/color-modes@0.17.4':
+    resolution: {integrity: sha512-YToAiH4eHSUl/tCeZM1la9994NP70aKicAVC9RzmkV6k95gz1ka9cbziM0qVPGv1+WNcEy8EA2taueaxXjyiUA==}
+    peerDependencies:
+      '@emotion/react': ^11.13.3
+      react: '>=18'
+
+  '@theme-ui/components@0.17.4':
+    resolution: {integrity: sha512-8J4h6/ym5KjRLC8lKbJ1Sr4BjS+UlhuGc0w6KcJJ9YTyeC1mEKo55h3BxTwol1uzWgyKu8wzJNbauiPc2mFsqA==}
+    peerDependencies:
+      '@emotion/react': ^11.13.3
+      '@theme-ui/theme-provider': ^0.17.4
+      react: '>=18'
+
+  '@theme-ui/core@0.17.4':
+    resolution: {integrity: sha512-Thi46ulVpTbsU+DafydCrt6AftWvG+NicsA62MasObd0sbrfPPZVjuZdEt6yNDwzWXaI2UjNmJa8G4Uty+ALrA==}
+    peerDependencies:
+      '@emotion/react': ^11.13.3
+      react: '>=18'
+
+  '@theme-ui/css@0.17.4':
+    resolution: {integrity: sha512-lyitzWdqszEK+T76ad4XUYQM+UCUadeFqMsjjKB8E461oQHxCKuV7fY/SRJr6hP/Zxk/mAEQnwNp2wjc0z8OIA==}
+    peerDependencies:
+      '@emotion/react': ^11.11.1
+
+  '@theme-ui/global@0.17.4':
+    resolution: {integrity: sha512-zCpfZ2OgBfveE/3fX8WmQYd6RujujlHybqNE3jUodYUoE2ZEO7papqk4eQPRpk58miYIiOBLUaxOC69wVNPjEA==}
+    peerDependencies:
+      '@emotion/react': ^11.13.3
+      react: '>=18'
+
+  '@theme-ui/preset-base@0.17.4':
+    resolution: {integrity: sha512-YL/0d/zfLnOV6glqpMe5E0zJCNAyiQU+cUOoNM5Nf4gLKoKBn7w8y0vgAArmO4KysnBjTpMUrQb6jh3++MySUw==}
+    peerDependencies:
+      '@theme-ui/css': ^0.17.4
+
+  '@theme-ui/preset-bootstrap@0.17.4':
+    resolution: {integrity: sha512-RSrprKJUUg7mE+k4jAY38RhMscTTlpSRdYMgkQPjkunA9kFZHs1lpvvq1rahUYp7KiHwJbf2459asQxi+qbREQ==}
+    peerDependencies:
+      '@theme-ui/css': ^0.17.4
+
+  '@theme-ui/preset-bulma@0.17.4':
+    resolution: {integrity: sha512-lKJwUlJLB1q/YmxkrCZrfslDxlCiHxZ5k0iaY/GczswWlZ5h7//jJNkEWP+vIuRwmaqf2IUwQEzqP8A5VkkjyA==}
+    peerDependencies:
+      '@theme-ui/css': ^0.17.4
+
+  '@theme-ui/preset-dark@0.17.4':
+    resolution: {integrity: sha512-V2UpAQBaztxlyFO4DPRcNSxWoHh1MmeiuoyipuzBsSMIFH8O5NPSSFHYwWRAWLlIm3lfWa+0JwD4Zi7DlX/D4g==}
+    peerDependencies:
+      '@theme-ui/css': ^0.17.4
+
+  '@theme-ui/preset-deep@0.17.4':
+    resolution: {integrity: sha512-USU7GWg7vgV9rMazjTVzoBEiZcoMpinecnQyGy7wIirIqvj83AqgKE/03IwXs7pT7ORGDlhU7/H7znUeEbBiBg==}
+    peerDependencies:
+      '@theme-ui/css': ^0.17.4
+
+  '@theme-ui/preset-funk@0.17.4':
+    resolution: {integrity: sha512-hrEJqKuSS2aC6xqKHbW9KguckRMUZ6+wkXC8qrQhCoLGNyRdinue9f1RVJDuN4ZpMBc/8Jgg2s1SlXtIQH0ghA==}
+    peerDependencies:
+      '@theme-ui/css': ^0.17.4
+
+  '@theme-ui/preset-future@0.17.4':
+    resolution: {integrity: sha512-jBSZb7Xt/Y/O6bssNjp8y/gtFtvrl34lG5NCrg8/TThj5XmcSE9AaZgkX21Q3yBent8sgFRkwj5Vg9Uk/6eF0g==}
+    peerDependencies:
+      '@theme-ui/css': ^0.17.4
+
+  '@theme-ui/preset-polaris@0.17.4':
+    resolution: {integrity: sha512-kfksaYaStpV9tp5v1dC1BEDzfQuO68cmyb0er9rwWUlJzXz97M4Fj9t0oY1YXzFTFF/xsI8UMn70guljY0BmqQ==}
+    peerDependencies:
+      '@theme-ui/css': ^0.17.4
+
+  '@theme-ui/preset-roboto@0.17.4':
+    resolution: {integrity: sha512-BrSxHyurUx9RWiWwZdRKc971yd3HxTvCHWvXsn8zLSigGeEnPobLaYC48ZXYALOejxcZaDakzDqV+F0Lyg2eGQ==}
+    peerDependencies:
+      '@theme-ui/css': ^0.17.4
+
+  '@theme-ui/preset-sketchy@0.17.4':
+    resolution: {integrity: sha512-GaiF/hfCL3Vp71F3QmT1X7e9czmWXtit+ySWi3H25jJ+PbxQwKbD1DJrwOgcxsy2Ve4aFRIATM5kM8+9QJCWRw==}
+
+  '@theme-ui/preset-swiss@0.17.4':
+    resolution: {integrity: sha512-0zixm5OaTdMpPIFI5Fzxg8v14Y20UWLZvUMktleK2joBWoCgYwyUxSp2144cOPlEMX0F9X2QVwZaQObjSjkmkw==}
+    peerDependencies:
+      '@theme-ui/css': ^0.17.4
+
+  '@theme-ui/preset-system@0.17.4':
+    resolution: {integrity: sha512-Zu6ur3lsxEEKnoRT7auaYj76hl5+GzcQDXk9g29DMiKMcTjMHOpd1rvURGW/h76WwFjxfzW1FKWFv+XVz/h7HA==}
+    peerDependencies:
+      '@theme-ui/css': ^0.17.4
+
+  '@theme-ui/preset-tailwind@0.17.4':
+    resolution: {integrity: sha512-175oa7qki8nCQq0SZu7fa0i5n/QM4R6MqWhKyv016DT1OZSEICJTxAJIUNUty3qb4Nzg6dXKHAAH2BhXXvIVdw==}
+    peerDependencies:
+      '@theme-ui/css': ^0.17.4
+
+  '@theme-ui/preset-tosh@0.17.4':
+    resolution: {integrity: sha512-YoGudtZzwM/UrUFHKOBcvs2ViIAuMGdFIMfArewHsuMom3gW9F4BvPhXNbUzZeMbrF9uVjSehd9+QbLDTp6eKQ==}
+    peerDependencies:
+      '@theme-ui/css': ^0.17.4
+
+  '@theme-ui/presets@0.17.4':
+    resolution: {integrity: sha512-EHPBcAvLGrP3jfAjfCrftFap1qfF1NEFiwMw4dGm+3eJGcRY5tE7oX9kOD1Pj0teISx5bLPrUzqvFSl8XPBGrw==}
+
+  '@theme-ui/theme-provider@0.17.4':
+    resolution: {integrity: sha512-A79XVNdkyLydTZFFsheWDsjOW16dSOAFhbByrJfM/9Y+4iJoaoQfFJ3IoCUvS7dBYgwTiPOBiEyeBgpDDTyclw==}
+    peerDependencies:
+      '@emotion/react': ^11.13.3
+      react: '>=18'
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/parse-json@4.0.2':
+    resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
+
+  '@types/styled-system@5.1.25':
+    resolution: {integrity: sha512-B1oyjE4oeAbVnkigcB0WqU2gPFuTwLV/KkLa/uJZWFB9JWVKq1Fs0QwodZXZ9Sq6cb9ngY4kDqRY/dictIchjA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -429,6 +718,10 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  babel-plugin-macros@3.1.0:
+    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
+    engines: {node: '>=10', npm: '>=6'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -501,6 +794,13 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
+  cosmiconfig@7.1.0:
+    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
+    engines: {node: '>=10'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -509,6 +809,9 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   csvtojson@2.0.14:
     resolution: {integrity: sha512-F7NNvhhDyob7OsuEGRsH0FM1aqLs/WYITyza3l+hTEEmOK9sGPBlYQZwlVG0ezCojXYpE17lhS5qL6BCOZSPyA==}
@@ -538,6 +841,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -570,6 +877,9 @@ packages:
 
   electron-to-chromium@1.5.335:
     resolution: {integrity: sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -702,6 +1012,9 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -798,6 +1111,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -817,6 +1133,9 @@ packages:
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -943,8 +1262,16 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -1100,6 +1427,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1110,6 +1441,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1203,6 +1538,15 @@ packages:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
       react: ^19.2.5
+
+  react-intersection-observer@10.0.3:
+    resolution: {integrity: sha512-luICLMbs0zxTO/70Zy7K5jOXkABPEVSAF8T3FdZUlctsrIaPLmx8TZe2SSA+CY2HGWfz2INyNTnp82pxNNsShA==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -1315,6 +1659,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -1355,6 +1703,12 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  styled-system@5.1.5:
+    resolution: {integrity: sha512-7VoD0o2R3RKzOzPK0jYrVnS8iJdfkKsQJNiLRDjikOpQVqQHns/DXWaPZOH4tIKkhAT7I6wIsy9FWTWh2X3q+A==}
+
+  stylis@4.2.0:
+    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -1373,12 +1727,21 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  theme-ui@0.17.4:
+    resolution: {integrity: sha512-kvmkAntXv/x362zdn7S9R16y+nIkNvT3jHJIc/g3k1kDeX6HQdkXf6w2yPK+GXIlPytJ9rx4Vvu03E59JlhxMQ==}
+    peerDependencies:
+      '@emotion/react': '>=11.1.1'
+      react: '>=18'
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  three@0.183.2:
+    resolution: {integrity: sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -1459,6 +1822,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
+    engines: {node: '>= 6'}
+
   yaml@2.6.1:
     resolution: {integrity: sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==}
     engines: {node: '>= 14'}
@@ -1472,12 +1839,158 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@chronogrove/ui@0.82.0(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@emotion/cache': 11.14.0
+      '@emotion/react': 11.14.0(react@19.2.5)
+      '@fortawesome/fontawesome-svg-core': 7.2.0
+      '@fortawesome/react-fontawesome': 3.3.0(@fortawesome/fontawesome-svg-core@7.2.0)(react@19.2.5)
+      '@theme-toggles/react': 4.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@theme-ui/presets': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-intersection-observer: 10.0.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      theme-ui: 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      three: 0.183.2
+    optionalDependencies:
+      next: 16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    transitivePeerDependencies:
+      - '@theme-ui/css'
+      - '@theme-ui/theme-provider'
+      - '@types/react'
+      - supports-color
 
   '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@emotion/babel-plugin@11.13.5':
+    dependencies:
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/runtime': 7.29.2
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/serialize': 1.3.3
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/cache@11.14.0':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+      '@emotion/sheet': 1.4.0
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      stylis: 4.2.0
+
+  '@emotion/hash@0.9.2': {}
+
+  '@emotion/is-prop-valid@0.8.8':
+    dependencies:
+      '@emotion/memoize': 0.7.4
+
+  '@emotion/memoize@0.7.4': {}
+
+  '@emotion/memoize@0.7.5': {}
+
+  '@emotion/memoize@0.9.0': {}
+
+  '@emotion/react@11.14.0(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.5)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      hoist-non-react-statics: 3.3.2
+      react: 19.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/serialize@1.3.3':
+    dependencies:
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/unitless': 0.10.0
+      '@emotion/utils': 1.4.2
+      csstype: 3.2.3
+
+  '@emotion/sheet@1.4.0': {}
+
+  '@emotion/unitless@0.10.0': {}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@emotion/utils@1.4.2': {}
+
+  '@emotion/weak-memoize@0.4.0': {}
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))':
     dependencies:
@@ -1524,6 +2037,17 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@fortawesome/fontawesome-common-types@7.2.0': {}
+
+  '@fortawesome/fontawesome-svg-core@7.2.0':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 7.2.0
+
+  '@fortawesome/react-fontawesome@3.3.0(@fortawesome/fontawesome-svg-core@7.2.0)(react@19.2.5)':
+    dependencies:
+      '@fortawesome/fontawesome-svg-core': 7.2.0
+      react: 19.2.5
 
   '@humanfs/core@0.19.1': {}
 
@@ -1689,13 +2213,211 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@styled-system/background@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/border@5.1.5':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/color@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/core@5.1.2':
+    dependencies:
+      object-assign: 4.1.1
+
+  '@styled-system/css@5.1.5': {}
+
+  '@styled-system/flexbox@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/grid@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/layout@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/position@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/shadow@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/should-forward-prop@5.1.5':
+    dependencies:
+      '@emotion/is-prop-valid': 0.8.8
+      '@emotion/memoize': 0.7.5
+      styled-system: 5.1.5
+
+  '@styled-system/space@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/typography@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/variant@5.1.5':
+    dependencies:
+      '@styled-system/core': 5.1.2
+      '@styled-system/css': 5.1.5
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
 
+  '@theme-toggles/react@4.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@theme-ui/color-modes@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@emotion/react': 11.14.0(react@19.2.5)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      deepmerge: 4.3.1
+      react: 19.2.5
+
+  '@theme-ui/components@0.17.4(@emotion/react@11.14.0(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@emotion/react': 11.14.0(react@19.2.5)
+      '@styled-system/color': 5.1.2
+      '@styled-system/should-forward-prop': 5.1.5
+      '@styled-system/space': 5.1.2
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      '@types/styled-system': 5.1.25
+      react: 19.2.5
+
+  '@theme-ui/core@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@emotion/react': 11.14.0(react@19.2.5)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      deepmerge: 4.3.1
+      react: 19.2.5
+
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5))':
+    dependencies:
+      '@emotion/react': 11.14.0(react@19.2.5)
+      csstype: 3.2.3
+
+  '@theme-ui/global@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@emotion/react': 11.14.0(react@19.2.5)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      react: 19.2.5
+
+  '@theme-ui/preset-base@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+
+  '@theme-ui/preset-bootstrap@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+
+  '@theme-ui/preset-bulma@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+
+  '@theme-ui/preset-dark@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+
+  '@theme-ui/preset-deep@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+
+  '@theme-ui/preset-funk@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+
+  '@theme-ui/preset-future@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+
+  '@theme-ui/preset-polaris@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+
+  '@theme-ui/preset-roboto@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+
+  '@theme-ui/preset-sketchy@0.17.4(@emotion/react@11.14.0(react@19.2.5))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+    transitivePeerDependencies:
+      - '@emotion/react'
+
+  '@theme-ui/preset-swiss@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+
+  '@theme-ui/preset-system@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+
+  '@theme-ui/preset-tailwind@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+
+  '@theme-ui/preset-tosh@0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+
+  '@theme-ui/presets@0.17.4(@emotion/react@11.14.0(react@19.2.5))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))':
+    dependencies:
+      '@theme-ui/preset-base': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+      '@theme-ui/preset-bootstrap': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+      '@theme-ui/preset-bulma': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+      '@theme-ui/preset-dark': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+      '@theme-ui/preset-deep': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+      '@theme-ui/preset-funk': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+      '@theme-ui/preset-future': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+      '@theme-ui/preset-polaris': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+      '@theme-ui/preset-roboto': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+      '@theme-ui/preset-sketchy': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/preset-swiss': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+      '@theme-ui/preset-system': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+      '@theme-ui/preset-tailwind': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+      '@theme-ui/preset-tosh': 0.17.4(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))
+    transitivePeerDependencies:
+      - '@emotion/react'
+      - '@theme-ui/css'
+
+  '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@emotion/react': 11.14.0(react@19.2.5)
+      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      react: 19.2.5
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/parse-json@4.0.2': {}
+
+  '@types/styled-system@5.1.25':
+    dependencies:
+      csstype: 3.2.3
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -1810,6 +2532,12 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
+  babel-plugin-macros@3.1.0:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      cosmiconfig: 7.1.0
+      resolve: 1.22.12
+
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.10.18: {}
@@ -1885,6 +2613,16 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  convert-source-map@1.9.0: {}
+
+  cosmiconfig@7.1.0:
+    dependencies:
+      '@types/parse-json': 4.0.2
+      import-fresh: 3.3.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.3
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -1892,6 +2630,8 @@ snapshots:
       which: 2.0.2
 
   cssesc@3.0.0: {}
+
+  csstype@3.2.3: {}
 
   csvtojson@2.0.14:
     dependencies:
@@ -1920,6 +2660,8 @@ snapshots:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
+
+  deepmerge@4.3.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -1955,6 +2697,10 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.335: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-abstract@1.24.2:
     dependencies:
@@ -2193,6 +2939,8 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-root@1.1.0: {}
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -2292,6 +3040,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.1:
@@ -2312,6 +3064,8 @@ snapshots:
       call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-arrayish@0.2.1: {}
 
   is-async-function@2.1.1:
     dependencies:
@@ -2443,7 +3197,11 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsesc@3.1.0: {}
+
   json-buffer@3.0.1: {}
+
+  json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
 
@@ -2611,11 +3369,20 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-type@4.0.0: {}
 
   picocolors@1.1.1: {}
 
@@ -2689,6 +3456,12 @@ snapshots:
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
+
+  react-intersection-observer@10.0.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
 
   react-is@16.13.1: {}
 
@@ -2862,6 +3635,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.5.7: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -2918,6 +3693,24 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.5
 
+  styled-system@5.1.5:
+    dependencies:
+      '@styled-system/background': 5.1.2
+      '@styled-system/border': 5.1.5
+      '@styled-system/color': 5.1.2
+      '@styled-system/core': 5.1.2
+      '@styled-system/flexbox': 5.1.2
+      '@styled-system/grid': 5.1.2
+      '@styled-system/layout': 5.1.2
+      '@styled-system/position': 5.1.2
+      '@styled-system/shadow': 5.1.2
+      '@styled-system/space': 5.1.2
+      '@styled-system/typography': 5.1.2
+      '@styled-system/variant': 5.1.5
+      object-assign: 4.1.1
+
+  stylis@4.2.0: {}
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -2962,6 +3755,17 @@ snapshots:
       - tsx
       - yaml
 
+  theme-ui@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@emotion/react': 11.14.0(react@19.2.5)
+      '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.5))
+      '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -2969,6 +3773,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  three@0.183.2: {}
 
   tinyglobby@0.2.16:
     dependencies:
@@ -3091,6 +3897,8 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  yaml@1.10.3: {}
 
   yaml@2.6.1:
     optional: true

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,21 +1,37 @@
+/* Color toggle: bundled by `@chronogrove/ui` (transitive `@theme-toggles/react`). Must precede @tailwind. */
+@import "@chronogrove/ui/color-toggle-styles";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
+html {
+  scroll-behavior: smooth;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
   }
 }
 
+html,
 body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+}
+
+/*
+ * Match Chronogrove’s page surface: head fallback CSS seeds `--theme-ui-colors-*` on :root
+ * before hydration. Body uses the active surface color.
+ */
+body {
+  background-color: var(--theme-ui-colors-background);
+  color: var(--theme-ui-colors-text);
+  /* Chronogrove `theme.fonts.body` (serif stack from @chronogrove/ui) */
+  font-family: Iowan Old Style, Apple Garamond, Georgia, Baskerville, "Times New Roman",
+    Droid Serif, Times, "Source Serif Pro", serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,49 +1,39 @@
-import localFont from "next/font/local";
 import "./globals.css";
 
-const geistSans = localFont({
-  src: "./fonts/GeistVF.woff",
-  variable: "--font-geist-sans",
-  weight: "100 900",
-});
-const geistMono = localFont({
-  src: "./fonts/GeistMonoVF.woff",
-  variable: "--font-geist-mono",
-  weight: "100 900",
-});
+import {
+  ChronogroveNextEmotionRegistry,
+  ChronogroveNextRootLayoutHead,
+} from "@chronogrove/ui/next";
+
+import Providers from "./providers";
+import SiteHeader from "../components/site-header";
 
 export const metadata = {
   title: "My Piano Repertoire | chrisvogt.me",
-  description: "The piano repertoire of Chris Vogt from San Francisco. Find more on www.chrisvogt.me.",
+  description:
+    "The piano repertoire of Chris Vogt from San Francisco. Find more on www.chrisvogt.me.",
 };
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <ChronogroveNextRootLayoutHead />
+      </head>
       <body
-        className={`bg-gray-800 text-white h-screen flex flex-col ${geistSans.variable} ${geistMono.variable} antialiased`}
+        suppressHydrationWarning
+        className="flex h-screen min-h-0 flex-col antialiased"
       >
-        {/* Top Bar */}
-        <header className="bg-gray-850 py-5 shadow-md border-b border-gray-700">
-          <div className="container mx-auto">
-            <h1 className="text-4xl mb-2 font-bold text-center">
-              My Piano Repertoire
-            </h1>
-            <a
-              className="text-center underline block text-sm text-gray-300 hover:text-gray-100"
-              href="https://docs.google.com/spreadsheets/d/1IRqgQCXxQ0KEqAdV119wN3FdhwVe_vtVjjPaowS5vFA/edit?usp=sharing"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              View Source on Google Sheets
-            </a>
-          </div>
-        </header>
-
-        {/* Main Content */}
-        <main className="flex-grow">
-          <div className="container mx-auto h-full p-4">{children}</div>
-        </main>
+        <ChronogroveNextEmotionRegistry>
+          <Providers>
+            <SiteHeader />
+            <main className="relative z-10 flex min-h-0 flex-1 flex-col">
+              <div className="container mx-auto flex min-h-0 flex-1 flex-col p-4">
+                {children}
+              </div>
+            </main>
+          </Providers>
+        </ChronogroveNextEmotionRegistry>
       </body>
     </html>
   );

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useColorMode } from "theme-ui";
 import { AgGridReact } from "ag-grid-react";
 import { ModuleRegistry, AllCommunityModule } from "ag-grid-community";
 import "ag-grid-community/styles/ag-grid.css";
@@ -51,7 +52,8 @@ const columnDefs = [
             href={params.value}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-blue-400 hover:underline"
+            className="hover:underline"
+            style={{ color: "var(--theme-ui-colors-primary, #422ea3)" }}
           >
             Sheet Music
           </a>
@@ -71,8 +73,12 @@ const defaultColDef = {
 };
 
 const HomePage = () => {
+  const [colorMode] = useColorMode();
   const [rowData, setRowData] = useState(null);
   const gridApiRef = useRef(null);
+
+  const agGridSurfaceClass =
+    colorMode === "dark" ? "ag-theme-quartz-dark" : "ag-theme-quartz";
 
   useEffect(() => {
     const fetchSongs = async () => {
@@ -138,16 +144,28 @@ const HomePage = () => {
   }, [rowData]);
 
   return (
-    <div className="ag-theme-quartz-auto-dark h-full w-full">
-      <AgGridReact
-        theme="legacy"
-        rowData={rowData ?? []}
-        columnDefs={columnDefs}
-        defaultColDef={defaultColDef}
-        overlayLoadingTemplate="<span class='ag-overlay-loading-center'>Loading songs...</span>"
-        overlayNoRowsTemplate="<span class='ag-overlay-no-rows-center'>No Rows to Show</span>"
-        onGridReady={onGridReady}
-      />
+    <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col">
+      {/*
+        Keep flex utilities off the ag-theme host — mixing display:flex with .ag-theme-* breaks
+        internal sizing; AG Grid uses NO_VALUE_SENTINEL (15538px) until the host has real dimensions.
+      */}
+      <div
+        className={`${agGridSurfaceClass} w-full overflow-hidden rounded-md shadow-sm`}
+        style={{
+          height: "calc(100dvh - 12rem)",
+          minHeight: "min(60vh, 480px)",
+        }}
+      >
+        <AgGridReact
+          theme="legacy"
+          rowData={rowData ?? []}
+          columnDefs={columnDefs}
+          defaultColDef={defaultColDef}
+          overlayLoadingTemplate="<span class='ag-overlay-loading-center'>Loading songs...</span>"
+          overlayNoRowsTemplate="<span class='ag-overlay-no-rows-center'>No Rows to Show</span>"
+          onGridReady={onGridReady}
+        />
+      </div>
     </div>
   );
 };

--- a/src/app/providers.jsx
+++ b/src/app/providers.jsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { ChronogroveNextAppShell } from "@chronogrove/ui/next";
+
+/**
+ * ChronogroveNextAppShell’s inner Box is not a flex container, so `flex-1` on `<main>` would not
+ * allocate height and AG Grid (`h-full`) collapsed to 0px. This column establishes the viewport
+ * height chain for header + main without changing @chronogrove/ui.
+ */
+export default function Providers({ children }) {
+  return (
+    <ChronogroveNextAppShell>
+      {/* h-screen (not min-h-screen) so header + main split a definite viewport height; avoids 0-height main */}
+      <div className="flex h-screen min-h-0 w-full flex-col">{children}</div>
+    </ChronogroveNextAppShell>
+  );
+}

--- a/src/components/site-header.jsx
+++ b/src/components/site-header.jsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Box, Heading } from "@theme-ui/components";
+import ColorToggle from "@chronogrove/ui/color-toggle";
+
+export default function SiteHeader() {
+  return (
+    <Box
+      as="header"
+      sx={{
+        position: "relative",
+        py: 5,
+        borderBottom: "1px solid",
+        borderBottomColor: "gray.6",
+        bg: "panel-background",
+        boxShadow: "default",
+      }}
+    >
+      <Box
+        sx={{
+          position: "absolute",
+          top: [2, 3],
+          right: [2, 3],
+        }}
+      >
+        <ColorToggle />
+      </Box>
+      <Box className="container mx-auto px-4">
+        <Heading
+          as="h1"
+          sx={{
+            fontSize: [4, 5],
+            mb: 2,
+            fontWeight: "bold",
+            textAlign: "center",
+            color: "text",
+          }}
+        >
+          My Piano Repertoire
+        </Heading>
+        <Box sx={{ textAlign: "center" }}>
+          <Box
+            as="a"
+            href="https://docs.google.com/spreadsheets/d/1IRqgQCXxQ0KEqAdV119wN3FdhwVe_vtVjjPaowS5vFA/edit?usp=sharing"
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{
+              fontSize: 1,
+              color: "textMuted",
+              textDecoration: "underline",
+              "&:hover": { color: "text" },
+            }}
+          >
+            View Source on Google Sheets
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
Integrates the published `@chronogrove/ui` package so repertoire shares Chronogrove’s Theme UI setup, color mode, and animated page background with the main site.

## Changes
- **App shell:** `ChronogroveNextEmotionRegistry`, `ChronogroveNextRootLayoutHead`, and `ChronogroveNextAppShell` (theme provider, dark-mode Color Bends + gradient overlay, route color-mode sync).
- **Header:** Client `SiteHeader` with Theme UI styling and `ColorToggle`; Sheets link uses `textMuted` for light-mode contrast.
- **AG Grid:** Legacy Quartz theme with layout fixes (no flex on `ag-theme-*` host, explicit height, stable viewport column). Grid theme follows `useColorMode`.
- **Tooling:** `transpilePackages` for `@chronogrove/ui` and related packages; new dependencies: `@chronogrove/ui`, `@emotion/react`, `@theme-ui/components`, `theme-ui`.

## Testing
- [x] `pnpm build` / `pnpm lint` locally

Made with [Cursor](https://cursor.com)