### PR TITLE
feat: cross-subdomain color mode + @chronogrove/ui 0.82.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
 
+## Configuration
+
+- **`NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMAIN`** (optional): Set to your site’s registrable domain (e.g. `chrisvogt.me`) in production so light/dark preference stays in sync with [www.chrisvogt.me](https://www.chrisvogt.me) via the shared first-party cookie from `@chronogrove/ui`. Omit for local-only `localStorage` behavior. Must match the value used on the Gatsby site (`GATSBY_COLOR_MODE_REGISTRABLE_DOMAIN` there).
+
+This app pins **`@chronogrove/ui`** to the same release line as `gatsby-theme-chronogrove` on www; bump both together when you upgrade the theme packages.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## How to update the repertoire data

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "convert:csv": "node scripts/convert-csv-to-json.js"
   },
   "dependencies": {
-    "@chronogrove/ui": "^0.82.1",
+    "@chronogrove/ui": "0.82.3",
     "@emotion/react": "^11.14.0",
     "@theme-ui/components": "^0.17.4",
     "ag-grid-community": "^35.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@chronogrove/ui':
-        specifier: ^0.82.1
-        version: 0.82.1(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 0.82.3
+        version: 0.82.3(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(react@19.2.5)
@@ -102,8 +102,8 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@chronogrove/ui@0.82.1':
-    resolution: {integrity: sha512-bcMVuV2DDg3rnfusi58qJZjHG+ELAoT5nx0qD1padVKQC3zZFiJDsIQtfmsk4mwD/5Uk8M7LAvrq4lwiJxDMug==}
+  '@chronogrove/ui@0.82.3':
+    resolution: {integrity: sha512-lfMSRsLEO9yocevzr3iR+ZV6LuXZ+MUkaSYC6XcbWGp0jOkCg6ctRTsms+8jOLroH5UcqftLbeVFqX4bS39RXQ==}
     peerDependencies:
       next: ^14.0.0 || ^15.0.0 || ^16.0.0
       react: ^18.0.0 || ^19.0.0
@@ -1677,7 +1677,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@chronogrove/ui@0.82.1(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@chronogrove/ui@0.82.3(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@emotion/cache': 11.14.0
       '@emotion/react': 11.14.0(react@19.2.5)

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -9,6 +9,10 @@ import ArticleColumnShell from "../components/article-column-shell";
 import Providers from "./providers";
 import SiteHeader from "../components/site-header";
 
+const crossDomainColorMode = process.env.NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMAIN?.trim()
+  ? { registrableDomain: process.env.NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMAIN.trim() }
+  : null;
+
 export const metadata = {
   title: "My Piano Repertoire | chrisvogt.me",
   description:
@@ -19,7 +23,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <ChronogroveNextRootLayoutHead />
+        <ChronogroveNextRootLayoutHead crossDomainColorMode={crossDomainColorMode} />
       </head>
       <body suppressHydrationWarning className="shell-body">
         <ChronogroveNextEmotionRegistry>

--- a/src/app/providers.jsx
+++ b/src/app/providers.jsx
@@ -3,6 +3,10 @@
 import { Box } from "@theme-ui/components";
 import { ChronogroveNextAppShell } from "@chronogrove/ui/next";
 
+const crossDomainColorMode = process.env.NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMAIN?.trim()
+  ? { registrableDomain: process.env.NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMAIN.trim() }
+  : null;
+
 /**
  * ChronogroveNextAppShell’s inner Box is not a flex container, so `flex: 1` on `<main>` would not
  * allocate height and AG Grid (`h-full`) collapsed to 0px. This column establishes the viewport
@@ -10,7 +14,7 @@ import { ChronogroveNextAppShell } from "@chronogrove/ui/next";
  */
 export default function Providers({ children }) {
   return (
-    <ChronogroveNextAppShell>
+    <ChronogroveNextAppShell crossDomainColorMode={crossDomainColorMode}>
       <Box
         sx={{
           display: "flex",


### PR DESCRIPTION
## Summary

Aligns this Next.js app with the Chronogrove cross-subdomain light/dark sync shipped in `@chronogrove/ui` / `gatsby-theme-chronogrove`, and documents how to enable it in production.

## Changes

- **`NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMAIN`**: When set (e.g. `chrisvogt.me`), passes `crossDomainColorMode` to `ChronogroveNextRootLayoutHead` and `ChronogroveNextAppShell` so head scripts and the color toggle use the same shared cookie as [www.chrisvogt.me](https://www.chrisvogt.me) (`GATSBY_COLOR_MODE_REGISTRABLE_DOMAIN` there).
- **`@chronogrove/ui`**: Pinned to **`0.82.3`** to match the UI version bundled with the published Gatsby theme line.
- **`README.md`**: Configuration section for the env var and version alignment notes.

## Deploy note

Set **`NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMAIN`** on Vercel (or your host) to the registrable domain, matching the Gatsby site’s value.

Made with [Cursor](https://cursor.com)