### PR TITLE
Release 0.1.2: Chronogrove parity, AG Grid after Back, dev origins

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  allowedDevOrigins: ["repertoire.dev-chrisvogt.me"],
   transpilePackages: [
     "@chronogrove/ui",
     "@theme-ui/components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repertoire.chrisvogt.me",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -11,7 +11,7 @@
     "convert:csv": "node scripts/convert-csv-to-json.js"
   },
   "dependencies": {
-    "@chronogrove/ui": "0.82.3",
+    "@chronogrove/ui": "0.83.1",
     "@emotion/react": "^11.14.0",
     "@theme-ui/components": "^0.17.4",
     "ag-grid-community": "^35.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@chronogrove/ui':
-        specifier: 0.82.3
-        version: 0.82.3(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 0.83.1
+        version: 0.83.1(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(react@19.2.5)
@@ -102,8 +102,8 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@chronogrove/ui@0.82.3':
-    resolution: {integrity: sha512-lfMSRsLEO9yocevzr3iR+ZV6LuXZ+MUkaSYC6XcbWGp0jOkCg6ctRTsms+8jOLroH5UcqftLbeVFqX4bS39RXQ==}
+  '@chronogrove/ui@0.83.1':
+    resolution: {integrity: sha512-Y5iwi9l44lNY6V87O0e1aEMD/ZEhxHuAdpbRydFW+/TcrKoWGLAwtsUryFAfiscMuXaKh6nUeXk/GKQQPXtDTw==}
     peerDependencies:
       next: ^14.0.0 || ^15.0.0 || ^16.0.0
       react: ^18.0.0 || ^19.0.0
@@ -1677,7 +1677,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@chronogrove/ui@0.82.3(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@chronogrove/ui@0.83.1(@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.5)))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(react@19.2.5))(react@19.2.5))(next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@emotion/cache': 11.14.0
       '@emotion/react': 11.14.0(react@19.2.5)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,3 +51,16 @@ body {
   flex: 1 1 0%;
   min-height: 0;
 }
+
+/*
+ * Skip-nav target must stay a flex child of `.shell-main` so the column height chain reaches
+ * AG Grid (same as when `ArticleColumnShell` was the direct child of `<main>`).
+ */
+.shell-skip-target {
+  flex: 1 1 0%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  outline: none;
+}

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -4,14 +4,12 @@ import {
   ChronogroveNextEmotionRegistry,
   ChronogroveNextRootLayoutHead,
 } from "@chronogrove/ui/next";
+import { SkipNavContent } from "@chronogrove/ui/skip-nav";
 
 import ArticleColumnShell from "../components/article-column-shell";
+import { chronogroveCrossDomainColorMode } from "../lib/chronogrove-cross-domain-color-mode";
 import Providers from "./providers";
 import SiteHeader from "../components/site-header";
-
-const crossDomainColorMode = process.env.NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMAIN?.trim()
-  ? { registrableDomain: process.env.NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMAIN.trim() }
-  : null;
 
 export const metadata = {
   title: "My Piano Repertoire | chrisvogt.me",
@@ -23,14 +21,16 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <ChronogroveNextRootLayoutHead crossDomainColorMode={crossDomainColorMode} />
+        <ChronogroveNextRootLayoutHead crossDomainColorMode={chronogroveCrossDomainColorMode} />
       </head>
       <body suppressHydrationWarning className="shell-body">
         <ChronogroveNextEmotionRegistry>
           <Providers>
             <SiteHeader />
             <main className="shell-main">
-              <ArticleColumnShell>{children}</ArticleColumnShell>
+              <SkipNavContent className="shell-skip-target">
+                <ArticleColumnShell>{children}</ArticleColumnShell>
+              </SkipNavContent>
             </main>
           </Providers>
         </ChronogroveNextEmotionRegistry>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -84,10 +84,20 @@ const defaultColDef = {
   sortable: true,
 };
 
+/** Avoid AG Grid warning #26 when remounting or after synthetic resize races the new instance. */
+function getLiveGridApi(apiRef) {
+  const api = apiRef.current;
+  if (!api) return null;
+  if (typeof api.isDestroyed === "function" && api.isDestroyed()) return null;
+  return api;
+}
+
 const HomePage = () => {
   const [colorMode] = useColorMode();
   const { theme } = useThemeUI();
   const [rowData, setRowData] = useState(null);
+  /** Incremented when the document is restored from bfcache so AG Grid remounts with a real layout. */
+  const [agGridMountKey, setAgGridMountKey] = useState(0);
   const gridApiRef = useRef(null);
 
   const agGridTheme = useMemo(() => {
@@ -199,18 +209,54 @@ const HomePage = () => {
     fetchSongs();
   }, []);
 
+  useEffect(() => {
+    /*
+     * Back from www (often BFCache): `persisted` / `pagehide` markers are unreliable for
+     * cross-origin hops, so the grid never remounted. The *initial* `pageshow` almost always runs
+     * before this effect attaches; any later `pageshow` is a history restore — remount the grid.
+     * Debounce collapses `pageshow` + `resume` in the same restore. Destroyed-API guards elsewhere
+     * make this safe without DevTools timing.
+     */
+    let scheduled = false;
+    let lastBumpMs = 0;
+    const bumpGridAfterHistoryRestore = () => {
+      const now = Date.now();
+      if (now - lastBumpMs < 450) return;
+      lastBumpMs = now;
+      if (scheduled) return;
+      scheduled = true;
+      requestAnimationFrame(() => {
+        scheduled = false;
+        setAgGridMountKey((n) => n + 1);
+      });
+    };
+
+    const onPageShow = () => {
+      bumpGridAfterHistoryRestore();
+    };
+
+    document.addEventListener("resume", bumpGridAfterHistoryRestore);
+    window.addEventListener("pageshow", onPageShow);
+    return () => {
+      window.removeEventListener("pageshow", onPageShow);
+      document.removeEventListener("resume", bumpGridAfterHistoryRestore);
+    };
+  }, []);
+
   const updateColumnVisibility = useCallback((api) => {
-    if (!api) return;
-    
+    if (!api || (typeof api.isDestroyed === "function" && api.isDestroyed())) return;
+
     const width = window.innerWidth;
     const isMobile = width < 768;
-    
+
     // AG Grid v35 uses setColumnsVisible (plural) with array of column IDs
     api.setColumnsVisible(["Quality", "Transpose"], !isMobile);
   }, []);
 
   const handleResize = useCallback(() => {
-    updateColumnVisibility(gridApiRef.current);
+    const api = getLiveGridApi(gridApiRef);
+    if (!api) return;
+    updateColumnVisibility(api);
   }, [updateColumnVisibility]);
 
   useEffect(() => {
@@ -220,17 +266,46 @@ const HomePage = () => {
     };
   }, [handleResize]);
 
-  const onGridReady = useCallback((params) => {
-    gridApiRef.current = params.api;
-    updateColumnVisibility(params.api);
-
-    if (rowData === null) {
-      params.api.setGridOption("loading", true);
+  const onGridPreDestroyed = useCallback((event) => {
+    if (gridApiRef.current === event.api) {
+      gridApiRef.current = null;
     }
-  }, [rowData, updateColumnVisibility]);
+  }, []);
+
+  const onGridReady = useCallback(
+    (params) => {
+      const api = params.api;
+      gridApiRef.current = api;
+      updateColumnVisibility(api);
+
+      if (rowData === null) {
+        api.setGridOption("loading", true);
+      } else if (rowData.length === 0) {
+        api.showNoRowsOverlay();
+        api.setGridOption("loading", false);
+      } else {
+        api.setGridOption("loading", false);
+        api.hideOverlay();
+      }
+
+      /*
+       * After first paint, nudge layout once the grid’s host has dimensions (avoids 0×0 when the
+       * main thread is faster than DevTools-throttled runs).
+       */
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          const live = getLiveGridApi(gridApiRef);
+          if (!live) return;
+          updateColumnVisibility(live);
+          window.dispatchEvent(new Event("resize"));
+        });
+      });
+    },
+    [rowData, updateColumnVisibility]
+  );
 
   useEffect(() => {
-    const api = gridApiRef.current;
+    const api = getLiveGridApi(gridApiRef);
     if (!api) return;
 
     if (rowData === null) {
@@ -275,29 +350,34 @@ const HomePage = () => {
         popular recording or release.
       </Box>
       {/*
-        Flex child with minHeight: 0 gives AG Grid a bounded height; avoid fixed calc now that the
-        shell uses a compact TopNavigation-style header.
+        Explicit vh height: after BFCache restore the `%`/flex height chain can resolve to 0 while
+        the cell still has min-height “space”. AG Grid needs a non-zero host box in px/vh terms.
       */}
       <Box
         sx={{
-          flex: 1,
-          /* Taller default viewport for long lists (~400 rows); still capped so tiny screens don’t overflow */
-          minHeight: ["min(52vh, 360px)", null, "min(68vh, 720px)"],
+          flex: "1 1 auto",
           width: "100%",
+          minHeight: "min(52vh, 360px)",
+          height: ["min(56vh, 420px)", null, "min(68vh, 720px)"],
+          minWidth: 0,
           overflow: "hidden",
           borderRadius: "default",
           boxShadow: "default",
         }}
       >
-        <AgGridReact
-          theme={agGridTheme}
-          rowData={rowData ?? []}
-          columnDefs={columnDefs}
-          defaultColDef={defaultColDef}
-          overlayLoadingTemplate="<span class='ag-overlay-loading-center'>Loading songs...</span>"
-          overlayNoRowsTemplate="<span class='ag-overlay-no-rows-center'>No Rows to Show</span>"
-          onGridReady={onGridReady}
-        />
+        <Box sx={{ width: "100%", height: "100%", minHeight: 0 }}>
+          <AgGridReact
+            key={agGridMountKey}
+            theme={agGridTheme}
+            rowData={rowData ?? []}
+            columnDefs={columnDefs}
+            defaultColDef={defaultColDef}
+            overlayLoadingTemplate="<span class='ag-overlay-loading-center'>Loading songs...</span>"
+            overlayNoRowsTemplate="<span class='ag-overlay-no-rows-center'>No Rows to Show</span>"
+            onGridPreDestroyed={onGridPreDestroyed}
+            onGridReady={onGridReady}
+          />
+        </Box>
       </Box>
     </Box>
   );

--- a/src/app/providers.jsx
+++ b/src/app/providers.jsx
@@ -2,10 +2,9 @@
 
 import { Box } from "@theme-ui/components";
 import { ChronogroveNextAppShell } from "@chronogrove/ui/next";
+import { SkipNavLink } from "@chronogrove/ui/skip-nav";
 
-const crossDomainColorMode = process.env.NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMAIN?.trim()
-  ? { registrableDomain: process.env.NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMAIN.trim() }
-  : null;
+import { chronogroveCrossDomainColorMode } from "../lib/chronogrove-cross-domain-color-mode";
 
 /**
  * ChronogroveNextAppShell’s inner Box is not a flex container, so `flex: 1` on `<main>` would not
@@ -14,7 +13,7 @@ const crossDomainColorMode = process.env.NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMA
  */
 export default function Providers({ children }) {
   return (
-    <ChronogroveNextAppShell crossDomainColorMode={crossDomainColorMode}>
+    <ChronogroveNextAppShell crossDomainColorMode={chronogroveCrossDomainColorMode}>
       <Box
         sx={{
           display: "flex",
@@ -25,6 +24,7 @@ export default function Providers({ children }) {
           height: "100vh",
         }}
       >
+        <SkipNavLink />
         {children}
       </Box>
     </ChronogroveNextAppShell>

--- a/src/components/site-header.jsx
+++ b/src/components/site-header.jsx
@@ -1,9 +1,7 @@
 "use client";
 
 /**
- * Temporary repertoire chrome: mirrors `gatsby-theme-chronogrove` `TopNavigation` layout
- * (brand + color toggle on the left, primary actions on the right). Replace with the shared
- * header once `@chronogrove/ui` publishes an app-shell / navigation export.
+ * Mirrors `gatsby-theme-chronogrove` `TopNavigation` (brand + color toggle, optional nav slot).
  *
  * @see gatsby-theme-chronogrove/theme/src/components/top-navigation.js
  */
@@ -26,7 +24,6 @@ export default function SiteHeader() {
         variant: "styles.TopNavigation",
         minHeight: "64px",
         color: "text",
-        bg: "panel-background",
       }}
     >
       <Container
@@ -69,8 +66,11 @@ export default function SiteHeader() {
           </Box>
         </Box>
 
-        {/* Right: sheet CTA */}
+        {/* Right: primary actions (same landmark pattern as theme `TopNavigation` nav) */}
         <Box
+          as="nav"
+          role="navigation"
+          aria-label="Site links"
           sx={{
             display: "flex",
             flexWrap: "wrap",

--- a/src/constants/article-column-container-sx.js
+++ b/src/constants/article-column-container-sx.js
@@ -1,9 +1,10 @@
+import { articleColumnContainerSx as chronogroveArticleColumnSx } from "@chronogrove/ui/article-column-container";
+
 /**
- * Matches the My Music index (`www.chrisvogt.me/src/pages/music.js`): a bit wider than the
- * default article column (`max(80ch, 50vw)` in `article-column-container-sx.js`).
+ * Base measure from `@chronogrove/ui` (blog / MDX). Wider third breakpoint matches the My Music
+ * index on www.chrisvogt.me (`max(95ch, 75vw)`).
  */
 export const articleColumnContainerSx = {
-  position: "relative",
+  ...chronogroveArticleColumnSx,
   width: ["", "", "max(95ch, 75vw)"],
-  lineHeight: 1.7,
 };

--- a/src/lib/chronogrove-cross-domain-color-mode.js
+++ b/src/lib/chronogrove-cross-domain-color-mode.js
@@ -1,0 +1,7 @@
+/**
+ * Same shape as Gatsby `gatsby-ssr` / `gatsby-browser` when `GATSBY_COLOR_MODE_REGISTRABLE_DOMAIN` is set.
+ * Keep head (`ChronogroveNextRootLayoutHead`) and client (`ChronogroveNextAppShell`) in lockstep.
+ */
+export const chronogroveCrossDomainColorMode = process.env.NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMAIN?.trim()
+  ? { registrableDomain: process.env.NEXT_PUBLIC_COLOR_MODE_REGISTRABLE_DOMAIN.trim() }
+  : null;


### PR DESCRIPTION
## Summary
Bumps the site to **v0.1.2** and aligns the repertoire app with www.chrisvogt.me Chronogrove UI patterns, fixes AG Grid after browser Back/BFCache, and allows the HTTPS dev host for Next.js.

## Changes
- **@chronogrove/ui** `0.83.1`, shared article column container sx, skip-nav + shell skip target layout, cross-domain color-mode helper, header/nav alignment with theme TopNavigation.
- **AG Grid**: remount on `pageshow`/`resume` (debounced), `onGridPreDestroyed` + live API guards, explicit `vh` host sizing so the grid cannot collapse after history restore.
- **Next.js**: `allowedDevOrigins` for `repertoire.dev-chrisvogt.me`.

## How to test
- Local: `pnpm dev`, open repertoire, follow header to www, Back — table should render.
- Dev HTTPS: confirm Turbopack/HMR without cross-origin dev warnings after `allowedDevOrigins`.


Made with [Cursor](https://cursor.com)